### PR TITLE
Ability to add query string. 

### DIFF
--- a/assets/publish_shortcuts.publish.js
+++ b/assets/publish_shortcuts.publish.js
@@ -14,6 +14,7 @@ var PublishShortcuts = {
 	
 	format_url: function(url) {
 		url = url.replace('{$root}', Symphony.Context.get('root'));
+		url = url.replace('{$filter}', location.search.substr(1,location.search.length));
 		return url;
 	}
 	

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -154,7 +154,8 @@ Class extension_publish_shortcuts extends Extension {
 		)));
 		$divgroup->appendChild($label);
 
-		$label = Widget::Label(__('Link') . '<i>' . __('Prefix with {$root} for absolute URLs') . '</i>');
+		$label = Widget::Label(__('Link') . '<i>' . __('Prefix with {$root} for absolute URLs. Add {$filter} to add
+		the query string to this url (like a filter).') . '</i>');
 		$label->appendChild(Widget::Input(
 			"settings[publish_shortcuts][" . $index . "][link]",
 			General::sanitize($shortcut['link']


### PR DESCRIPTION
Added ability to append {$filter} to the url. {$filter} being the query string of the page the button is on.

I chose {$filter} because you used {$root} for the prepend. (personally i think using the $ makes it look too much like parameters which they clearly are not ;-) )

Use case:

When you are on a page that is filtered (?filter=[field]:[value]) and you want to pass this filter to another extension (for example: to export a .csv) this enables you to do just that.
